### PR TITLE
Switch from mypy to dmypy in pre-commit for faster type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,16 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+  # Type checking
+  - repo: local
     hooks:
-      - id: mypy
-        additional_dependencies: [types-pyyaml>=6.0.12]
-        args: [--ignore-missing-imports]
+      - id: dmypy
+        name: dmypy
+        entry: uv run dmypy run
+        args: [--timeout, "3600"]
+        language: system
+        pass_filenames: false
+        always_run: true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ warn_redundant_casts = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
+[[tool.mypy.overrides]]
+module = "yaml"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
## Summary
- Replace standard mypy pre-commit hook with dmypy (mypy daemon) for faster incremental type checking
- Add explicit mypy override for yaml module to suppress missing stub warnings

## Benefits
The dmypy daemon provides significantly faster type checking performance by caching type information between runs, which is especially beneficial for larger codebases and frequent pre-commit checks.

## Test plan
- [x] Verified dmypy hook passes with `pre-commit run --all-files`
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)